### PR TITLE
 Move component modification of output times

### DIFF
--- a/workflow/rocoto/gfs_tasks.py
+++ b/workflow/rocoto/gfs_tasks.py
@@ -929,21 +929,7 @@ class GFSTasks(Tasks):
     @staticmethod
     def _get_ufs_postproc_grps(cdump, config, component='atmos'):
 
-        # Make a local copy of the config to avoid modifying the original
-        local_config = config.copy()
-
-        # Ocean/Ice components do not have a HF output option like the atmosphere
-        if component in ['ocean', 'ice']:
-            local_config['FHMAX_HF_GFS'] = config['FHMAX_GFS']
-            local_config['FHOUT_HF_GFS'] = config['FHOUT_OCNICE_GFS']
-            local_config['FHOUT_GFS'] = config['FHOUT_OCNICE_GFS']
-            local_config['FHOUT'] = config['FHOUT_OCNICE']
-
-        fhrs = Tasks._get_forecast_hours(cdump, local_config)
-
-        # ocean/ice components do not have fhr 0 as they are averaged output
-        if component in ['ocean', 'ice']:
-            fhrs.remove(0)
+        fhrs = Tasks._get_forecast_hours(cdump, config, component=component)
 
         nfhrs_per_grp = config.get('NFHRS_PER_GROUP', 1)
         ngrps = len(fhrs) // nfhrs_per_grp if len(fhrs) % nfhrs_per_grp == 0 else len(fhrs) // nfhrs_per_grp + 1

--- a/workflow/rocoto/tasks.py
+++ b/workflow/rocoto/tasks.py
@@ -129,8 +129,6 @@ class Tasks:
             local_config['FHMAX_HF_GFS'] = config['FHMAX_GFS']
             local_config['FHOUT_HF_GFS'] = config['FHOUT_OCNICE_GFS']
             local_config['FHOUT_GFS'] = config['FHOUT_OCNICE_GFS']
-            # ocean/ice components do not have fhr 0 as they are averaged output
-            local_config['FHMIN'] = config['FHOUT_OCNICE']
             local_config['FHOUT'] = config['FHOUT_OCNICE']
 
         fhmin = local_config['FHMIN']
@@ -148,6 +146,10 @@ class Tasks:
             fhout_hf = local_config['FHOUT_HF_GFS']
             fhrs_hf = range(fhmin, fhmax_hf + fhout_hf, fhout_hf)
             fhrs = list(fhrs_hf) + list(range(fhrs_hf[-1] + fhout, fhmax + fhout, fhout))
+
+        # ocean/ice components do not have fhr 0 as they are averaged output
+        if component in ['ocean', 'ice']:
+            fhrs.remove(0)
 
         return fhrs
 

--- a/workflow/rocoto/tasks.py
+++ b/workflow/rocoto/tasks.py
@@ -120,20 +120,32 @@ class Tasks:
                                              rocoto_conversion_dict.get)
 
     @staticmethod
-    def _get_forecast_hours(cdump, config) -> List[str]:
-        fhmin = config['FHMIN']
-        fhmax = config['FHMAX']
-        fhout = config['FHOUT']
+    def _get_forecast_hours(cdump, config, component='atmos') -> List[str]:
+        # Make a local copy of the config to avoid modifying the original
+        local_config = config.copy()
+
+        # Ocean/Ice components do not have a HF output option like the atmosphere
+        if component in ['ocean', 'ice']:
+            local_config['FHMAX_HF_GFS'] = config['FHMAX_GFS']
+            local_config['FHOUT_HF_GFS'] = config['FHOUT_OCNICE_GFS']
+            local_config['FHOUT_GFS'] = config['FHOUT_OCNICE_GFS']
+            # ocean/ice components do not have fhr 0 as they are averaged output
+            local_config['FHMIN'] = config['FHOUT_OCNICE']
+            local_config['FHOUT'] = config['FHOUT_OCNICE']
+
+        fhmin = local_config['FHMIN']
+        fhmax = local_config['FHMAX']
+        fhout = local_config['FHOUT']
 
         # Get a list of all forecast hours
         fhrs = []
         if cdump in ['gdas']:
             fhrs = list(range(fhmin, fhmax + fhout, fhout))
         elif cdump in ['gfs', 'gefs']:
-            fhmax = config['FHMAX_GFS']
-            fhout = config['FHOUT_GFS']
-            fhmax_hf = config['FHMAX_HF_GFS']
-            fhout_hf = config['FHOUT_HF_GFS']
+            fhmax = local_config['FHMAX_GFS']
+            fhout = local_config['FHOUT_GFS']
+            fhmax_hf = local_config['FHMAX_HF_GFS']
+            fhout_hf = local_config['FHOUT_HF_GFS']
             fhrs_hf = range(fhmin, fhmax_hf + fhout_hf, fhout_hf)
             fhrs = list(fhrs_hf) + list(range(fhrs_hf[-1] + fhout, fhmax + fhout, fhout))
 


### PR DESCRIPTION

# Description
The forecast hour list used to create the rocoto product metatasks were being made in the groups function instead of the forecast hour list function.

# Type of change
- Maintenance (code refactor, clean-up, new CI test, etc.)

# Change characteristics
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO

# How has this been tested?
Not

# Checklist
- [ ] Any dependent changes have been merged and published
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [ ] I have made corresponding changes to the documentation if necessary
