### PR TITLE
Restore upp from ufswm

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -26,10 +26,6 @@
 [submodule "sorc/gsi_monitor.fd"]
   path = sorc/gsi_monitor.fd
   url = https://github.com/NOAA-EMC/GSI-Monitor.git
-[submodule "sorc/upp.fd"]
-  path = sorc/upp.fd
-  url = https://github.com/NOAA-EMC/UPP.git
-  ignore = dirty
 [submodule "sorc/jcb"]
   path = sorc/jcb
   url = https://github.com/noaa-emc/jcb

--- a/sorc/build_upp.sh
+++ b/sorc/build_upp.sh
@@ -26,6 +26,6 @@ if [[ ! -d "../exec" ]]; then
   mkdir -p ../exec
 fi
 
-cd upp.fd/tests
+cd ufs_model.fd/FV3/upp/tests
 # shellcheck disable=SC2086
 BUILD_JOBS=${BUILD_JOBS:-8} ./compile_upp.sh ${_opts}

--- a/sorc/link_workflow.sh
+++ b/sorc/link_workflow.sh
@@ -362,11 +362,10 @@ fi
 #--link source code directories
 #------------------------------
 cd "${HOMEgfs}/sorc" || exit 8
-# TODO: Commenting out until UPP is up-to-date with Rocky-8.
-#if [[ -d ufs_model.fd ]]; then
-#  [[ -d upp.fd ]] && rm -rf upp.fd
-#  ${LINK} ufs_model.fd/FV3/upp upp.fd
-#fi
+if [[ -d ufs_model.fd ]]; then
+  [[ -d upp.fd ]] && rm -rf upp.fd
+  ${LINK} ufs_model.fd/FV3/upp upp.fd
+fi
 
 if [[ -d gsi_enkf.fd ]]; then
   [[ -d gsi.fd ]] && rm -rf gsi.fd


### PR DESCRIPTION
This PR:
- removes upp submodule
- uses upp from the ufs-weather-model
- restores the build and link that were hacked during the Hera Rocky 8 transition to allow for UPP submodule