### PR TITLE
adding gocart changes for head of develop

### DIFF
--- a/parm/ufs/gocart/CA2G_instance_CA.bc.rc
+++ b/parm/ufs/gocart/CA2G_instance_CA.bc.rc
@@ -1,5 +1,5 @@
 #
-# Resource file for Black Carbon parameters. 
+# Resource file for Black Carbon parameters.
 #
 
 nbins:  2
@@ -16,8 +16,22 @@ aviation_vertical_layers: 0.0 100.0 9.0e3 10.0e3
 # Initially hydrophobic portion
 hydrophobic_fraction: 0.8
 
+# Rate of conversion of hydrophobic to hydrophilic [days]
+time_days_hydrophobic_to_hydrophilic: 2.5
+
+# Rate of chemical destruction of carbon species [days]
+time_days_chemical_destruction: -1.  -1.
+
+# Wet Removal Scheme Option | gocart, ufs
+wet_removal_scheme: ufs # default value
+
+# Rainout efficiency per bin for wet_removal_scheme == ufs
+fwet_ice: 0.0 1.0
+fwet_snow: 0.0 1.0
+fwet_rain: 0.0 1.0
+
 # Scavenging efficiency per bin [km-1] (NOT USED UNLESS RAS IS CALLED)
-fscav: 0.0  0.4 
+fscav: 0.0  0.4
 
 # Dry particle density [kg m-3]
 particle_density: 1800   1800

--- a/parm/ufs/gocart/CA2G_instance_CA.br.rc
+++ b/parm/ufs/gocart/CA2G_instance_CA.br.rc
@@ -21,6 +21,18 @@ pom_ca_ratio: 1.8
 # Initially hydrophobic portion
 hydrophobic_fraction: 0.5
 
+# Rate of conversion of hydrophobic to hydrophilic [days]
+time_days_hydrophobic_to_hydrophilic: 2.5
+
+# Rate of chemical destruction of carbon species [days]
+time_days_chemical_destruction: -1.  -1.
+
+# Wet Removal Scheme Option | gocart, ufs
+wet_removal_scheme: ufs
+fwet_ice: 0.0 0.4
+fwet_snow: 0.0 0.4
+fwet_rain: 0.0 0.4
+
 # Scavenging efficiency per bin [km-1] (NOT USED UNLESS RAS IS CALLED)
 fscav: 0.0  0.4
 

--- a/parm/ufs/gocart/CA2G_instance_CA.oc.rc
+++ b/parm/ufs/gocart/CA2G_instance_CA.oc.rc
@@ -1,5 +1,5 @@
 #
-# Resource file for Organic Carbon parameters. 
+# Resource file for Organic Carbon parameters.
 #
 
 aerosol_radBands_optics_file: ExtData/optics/opticsBands_OC.v1_3.RRTMG.nc
@@ -26,8 +26,22 @@ rhFlag: 0
 # Initially hydrophobic portion
 hydrophobic_fraction: 0.5
 
+# Rate of conversion of hydrophobic to hydrophilic [days]
+time_days_hydrophobic_to_hydrophilic: 2.5
+
+# Rate of chemical destruction of carbon species [days]
+time_days_chemical_destruction: -1.  -1.
+
+# Wet Removal Scheme Option | gocart, ufs
+wet_removal_scheme: ufs
+
+# Rainout efficiency per bin for wet_removal_scheme == ufs
+fwet_ice: 0.0 1.0
+fwet_snow: 0.0 1.0
+fwet_rain: 0.0 1.0
+
 # Scavenging efficiency per bin [km-1] (NOT USED UNLESS RAS IS CALLED)
-fscav: 0.0  0.4 
+fscav: 0.0  0.4
 
 # Dry particle density [kg m-3]
 particle_density: 1800   1800
@@ -43,6 +57,6 @@ sigma: 2.20  2.20
 
 pressure_lid_in_hPa: 0.01
 
-nbins: 2 
+nbins: 2
 
 point_emissions_srcfilen: /dev/null

--- a/parm/ufs/gocart/DU2G_instance_DU.rc
+++ b/parm/ufs/gocart/DU2G_instance_DU.rc
@@ -1,5 +1,5 @@
 #
-# Resource file Dust parameters. 
+# Resource file Dust parameters.
 #
 
 aerosol_radBands_optics_file: ExtData/optics/opticsBands_DU.v15_3.RRTMG.nc
@@ -22,6 +22,17 @@ Ch_DU: 0.2 0.2 0.07 0.07 0.07 0.056
 # Scavenging efficiency per bin [km-1]
 fscav: 0.2  0.2  0.2  0.2  0.2   #
 
+# clay fraction scaling factor
+soil_clay_factor: 1.0
+
+# Wet Removal Scheme Option | gocart, ufs
+wet_removal_scheme: ufs
+
+# Rainout efficiency per bin for wet_removal_scheme == ufs
+fwet_ice: 0.8 0.8 0.8 1.0 1.0
+fwet_snow: 0.8 0.8 0.8 1.0 1.0
+fwet_rain: 0.8 0.8 0.8 1.0 1.0
+
 # Molecular weight of species [kg mole-1]
 molecular_weight: 0.1  0.1  0.1  0.1  0.1
 
@@ -31,7 +42,7 @@ fnum: 2.45e14  3.28e13  6.52e12  9.89e11 1.76e11
 rhFlag: 0
 
 # Maring settling velocity correction
-maringFlag: .true. 
+maringFlag: .true.
 
 nbins: 5
 
@@ -41,8 +52,9 @@ pressure_lid_in_hPa: 0.01
 emission_scheme: fengsha       # choose among: fengsha, ginoux, k14
 
 # FENGSHA settings
-alpha: 0.1
+alpha: 0.16
 gamma: 1.0
 soil_moisture_factor: 1
 soil_drylimit_factor: 1
 vertical_to_horizontal_flux_ratio_limit: 2.e-04
+drag_partition_option: 2

--- a/parm/ufs/gocart/ExtData.other
+++ b/parm/ufs/gocart/ExtData.other
@@ -7,13 +7,15 @@
 TROPP            'Pa'    Y       N                  -            0.0      1.0      TROPP         /dev/null:10000.
 
 #====== Dust Imports =================================================
-# FENGSHA input files. Note: regridding should be N or E - Use files with _FillValue != NaN 
+# FENGSHA input files. Note: regridding should be N or E - Use files with _FillValue != NaN
 DU_CLAY           '1'  Y E           -           none none clayfrac    ExtData/nexus/FENGSHA/FENGSHA_2022_NESDIS_inputs_10km_v3.2.nc
 DU_SAND           '1'  Y E           -           none none sandfrac    ExtData/nexus/FENGSHA/FENGSHA_2022_NESDIS_inputs_10km_v3.2.nc
 DU_SILT           '1'  Y E           -           none none siltfrac    /dev/null
-DU_SSM            '1'  Y E           -           none none sep         ExtData/nexus/FENGSHA/FENGSHA_2022_NESDIS_inputs_10km_v3.2.nc
-DU_RDRAG          '1'  Y E %y4-%m2-%d2t12:00:00  none none albedo_drag ExtData/nexus/FENGSHA/FENGSHA_2022_NESDIS_inputs_10km_v3.2.nc
+DU_SSM            '1'  Y E           -           none none sep         /dev/null:1.0
 DU_UTHRES         '1'  Y E           -           none none uthres      ExtData/nexus/FENGSHA/FENGSHA_2022_NESDIS_inputs_10km_v3.2.nc
+DU_RDRAG          '1'  Y E %y4-%m2-%d2t12:00:00  none none PC          /gpfs/f6/bil-fire3/world-shared/Emissions/GEFS_ExtData/nexus/FENGSHA/FENGSHA_New_Method_NESDISv1.1_9km.nc
+DU_GVF            '1'  Y E %y4-%m2-%d2T12:00:00  none none GVF         /gpfs/f6/bil-fire3/world-shared/Emissions/GEFS_ExtData/nexus/FENGSHA/FENGSHA_GVF_LAI2.nc
+DU_LAI            '1'  Y E %y4-%m2-%d2T12:00:00  none none LAI         /gpfs/f6/bil-fire3/world-shared/Emissions/GEFS_ExtData/nexus/FENGSHA/FENGSHA_GVF_LAI2.nc
 
 #====== Sulfate Sources =================================================
 # Anthropogenic (BF & FF) emissions -- allowed to input as two layers

--- a/parm/ufs/gocart/SS2G_instance_SS.rc
+++ b/parm/ufs/gocart/SS2G_instance_SS.rc
@@ -14,7 +14,7 @@ radius_upper: 0.1 0.5 1.5 5.0 10.0
 particle_density: 2200. 2200. 2200. 2200. 2200.
 
 # Scavenging efficiency per bin [km-1]
-fscav: 0.4  0.4  0.4  0.4  0.4 
+fscav: 0.4  0.4  0.4  0.4  0.4
 
 # Emissions methods and scaling
 emission_scheme: 3                                     # 1 for Gong 2003, 2 for ...
@@ -39,5 +39,13 @@ particle_radius_number: 0.066  0.176  0.885  2.061  6.901
 nbins: 5
 
 pressure_lid_in_hPa: 0.01
+
+# Wet Removal Scheme Option | gocart, ufs
+wet_removal_scheme: ufs
+
+# Rainout efficiency per bin for wet_removal_scheme == ufs
+fwet_ice: 1.0 1.0 1.0 1.0 1.0
+fwet_snow: 1.0 1.0 1.0 1.0 1.0
+fwet_rain: 1.0 1.0 1.0 1.0 1.0
 
 

--- a/parm/ufs/gocart/SU2G_instance_SU.rc
+++ b/parm/ufs/gocart/SU2G_instance_SU.rc
@@ -8,7 +8,8 @@ aerosol_monochromatic_optics_file: ExtData/monochromatic/optics_SU.v1_3.nc
 nbins: 4
 
 # Volcanic pointwise sources | degassing only | replace with path to historical volcanic emissions for scientific runs
-volcano_srcfilen: ExtData/nexus/VOLCANO/v2021-09/so2_volcanic_emissions_CARN_v202005.degassing_only.rc
+volcano_srcfilen_explosive: /dev/null
+volcano_srcfilen_degassing: ExtData/nexus/VOLCANO/v2021-09/so2_volcanic_emissions_CARN_v202005.degassing_only.rc
 
 # Heights [m] of LTO, CDS and CRS aviation emissions layers
 aviation_vertical_layers: 0.0 100.0 9.0e3 10.0e3


### PR DESCRIPTION
This pull request introduces several updates to configuration files for the UFS GOCART model, focusing on adding new parameters, improving wet removal schemes, and updating external data sources. Below is a summary of the most important changes, grouped by theme.

### Wet Removal Scheme Enhancements:
* Added `wet_removal_scheme: ufs` along with rainout efficiency parameters (`fwet_ice`, `fwet_snow`, `fwet_rain`) to multiple configuration files, including `CA2G_instance_CA.bc.rc`, `CA2G_instance_CA.br.rc`, `CA2G_instance_CA.oc.rc`, `DU2G_instance_DU.rc`, and `SS2G_instance_SS.rc`. These parameters define the efficiency of wet removal processes for different precipitation types. [[1]](diffhunk://#diff-868866b7abe13249cb35169ab2fc4ae9bcb56fc0777518d886778451dc08e214R19-R32) [[2]](diffhunk://#diff-9b5c009932e4d4d5ec402ac2f5815d461dbe7d91cb9a10a62a7e0df409ce5367R24-R35) [[3]](diffhunk://#diff-ec2da60e5d01cc93177afdad34eb646cff906daa081a1142a40a65952e7cfef3R29-R42) [[4]](diffhunk://#diff-d9370b3a0a2be8cc6de05c1b6b6c97913e3c15d7e52e3dbb1e3498e8f73d6e99R25-R35) [[5]](diffhunk://#diff-96bb0170283b2fb4ba4eef7133c12ce37c215e4b007cf6e67022c1e063c96c13R43-R50)

### New Parameters for Physical and Chemical Processes:
* Introduced `time_days_hydrophobic_to_hydrophilic` (conversion rate of hydrophobic to hydrophilic aerosols) and `time_days_chemical_destruction` (rate of chemical destruction of carbon species) in `CA2G_instance_CA.bc.rc`, `CA2G_instance_CA.br.rc`, and `CA2G_instance_CA.oc.rc`. These parameters enhance the representation of aerosol lifecycle processes. [[1]](diffhunk://#diff-868866b7abe13249cb35169ab2fc4ae9bcb56fc0777518d886778451dc08e214R19-R32) [[2]](diffhunk://#diff-9b5c009932e4d4d5ec402ac2f5815d461dbe7d91cb9a10a62a7e0df409ce5367R24-R35) [[3]](diffhunk://#diff-ec2da60e5d01cc93177afdad34eb646cff906daa081a1142a40a65952e7cfef3R29-R42)
* Added `soil_clay_factor` in `DU2G_instance_DU.rc` to scale clay fraction in dust emissions.

### Updates to External Data Sources:
* Updated external data paths in `ExtData.other` for variables such as `DU_RDRAG`, `DU_GVF`, and `DU_LAI`, pointing to new datasets for albedo drag, green vegetation fraction, and leaf area index.
* Separated volcanic emissions into `volcano_srcfilen_explosive` and `volcano_srcfilen_degassing` in `SU2G_instance_SU.rc`, improving the handling of volcanic SO₂ sources.

### Dust Emission Scheme Adjustments:
* Modified the `alpha` parameter in the Fengsha dust emission scheme from `0.1` to `0.16` and added `drag_partition_option: 2` in `DU2G_instance_DU.rc`, refining the dust emission calculations.<!--
 